### PR TITLE
fix: call detectChanges() instead of markForCheck

### DIFF
--- a/projects/rx-subscribe/src/lib/rx-subscribe.directive.ts
+++ b/projects/rx-subscribe/src/lib/rx-subscribe.directive.ts
@@ -40,7 +40,7 @@ export class RxSubscribeDirective<T> implements OnChanges, OnDestroy {
       } else {
         this.viewRef.context.$implicit = value;
       }
-      this.viewRef.markForCheck();
+      this.viewRef.detectChanges();
     });
   }
 


### PR DESCRIPTION
BREAKING CHANGE: previous, rxSubscribe directive has not triggered change detection, so it doesn't work without zones. Now it triggers CD by itself.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

It can work without zones. 

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If the stream emits too many values frequently, it may affect performance badly.

## Other information
